### PR TITLE
Change logger implementation for Chrome 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 ####Changed
 - Change logger implementation so it works on Chrome 50 (73ac30a8e3231fb78bc3dd0fbbd15dcef1ad76c4)
 
-####Fixed
-- Add missing doc images (c0ec6e8e0d63147385cc8b8208752ab1dd157f05)
-- Removed broken links from `README.md` (03327b519777fc176aef61c13e151eaf4cf29876)
 
 ## 1.11.1 (2021-01-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.12.0 (2021-04-15)
+
+####Changed
+- Change logger implementation so it works on Chrome 50 (73ac30a8e3231fb78bc3dd0fbbd15dcef1ad76c4)
+
+####Fixed
+- Add missing doc images (c0ec6e8e0d63147385cc8b8208752ab1dd157f05)
+- Removed broken links from `README.md` (03327b519777fc176aef61c13e151eaf4cf29876)
+
 ## 1.11.1 (2021-01-11)
 
 ####Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/seven-gravity-gateway",
-  "version": "1.11.1",
+  "version": "1.12.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/seven-gravity-gateway",
-  "version": "1.12.0-alpha.0",
+  "version": "1.12.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "gravity",
     "gateway"
   ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "author": "Ivan Pandzic <pandzic.ivan@nsoft.ba>",
   "contributors": [
     "Jadranko Dragoje <dragoje.jadranko@nsoft.ba>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nsoft/seven-gravity-gateway",
   "private": false,
-  "version": "1.11.1",
+  "version": "1.12.0-alpha.0",
   "description": "Seven Gravity Gateway",
   "homepage": "http://7platform.com",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nsoft/seven-gravity-gateway",
   "private": false,
-  "version": "1.12.0-alpha.0",
+  "version": "1.12.0-alpha.1",
   "description": "Seven Gravity Gateway",
   "homepage": "http://7platform.com",
   "scripts": {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -9,9 +9,9 @@ var logger = {
             var type = args.splice(0,1);
 
             if(console[type]) {
-                console[type].apply(this, args);
+                console[type].call(console, args);
             } else {
-                console.log.apply(this, args);
+                console.log.call(console, args);
             }
         }
     }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -9,9 +9,9 @@ var logger = {
             var type = args.splice(0,1);
 
             if(console[type]) {
-                console[type].call(console, args);
+                console[type].apply(console, args);
             } else {
-                console.log.call(console, args);
+                console.log.apply(console, args);
             }
         }
     }


### PR DESCRIPTION
- Changed arguments passed to console calls (https://stackoverflow.com/questions/8159233/typeerror-illegal-invocation-on-console-log-apply)
- Removed `publishConfig` from package since it's not compatible with newer npm versions