### PR TITLE
Async callback returns event object

### DIFF
--- a/src/pub_sub.js
+++ b/src/pub_sub.js
@@ -31,7 +31,7 @@ var pubSub = {
         var subscription = false;
         if(typeof callback === 'function') {
             subscription = this.subscribe(action, function(response) {
-                callback(response);
+                callback(response.data);
                 subscription.remove();
             });
         }

--- a/test/pub_sub.js
+++ b/test/pub_sub.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var sinon = require('sinon');
 
 describe('Subscribe/Unsubscribe funcionality', function() {
     var pubSub = require('../src/pub_sub'),
@@ -81,6 +82,28 @@ describe('Subscribe/Unsubscribe funcionality', function() {
     it('Once subscription doesn`t exists: Should be succesfull', function() {
         var subscription = pubSub.isSubscribed('betslip.edit');
         assert.equal(subscription, false);
+    });
+
+    it('Once subscription callback: Should execute callback', function() {
+        var callback = sinon.spy();
+        pubSub.once('Tickets.Validate', callback);
+        pubSub.publish('Tickets.Validate');
+        assert.equal(callback.called, true);
+    });
+
+    it('Once subscription callback: Should execute callback with passed data', function() {
+        var eventData = {
+            action: 'Tickets.Validate',
+            msgSender: 'Slave',
+            slaveId: 'Dummy',
+            data: {
+                ticket: false
+            }
+        };
+        var callback = sinon.spy();
+        pubSub.once('Tickets.Validate', callback);
+        pubSub.publish('Tickets.Validate', eventData);
+        assert.strictEqual(callback.getCall(0).calledWith(eventData.data), true);
     });
 });
 


### PR DESCRIPTION
Async callback returns more than it should. Documentation described that it should expose only data returned from Master in response object. E.g.

```js
// Slave
{gatewayInstance}.emitAsync({
    action : 'Get.Data',
}).then(function(res) {
  // should be {someData: 'data'}, instead it was {evetnName, uuid, resolve, reject, // lot of internal gateway properties}
   console.log(res)
})


// master
{gatewayInstance}.on('Betslip.Add', function(event) {
  // do some logic...
  setTimeout(function(){
    event.resolve({someData: 'data'});
 }, 1000);
});
```