### PR TITLE
Async not resolving

### DIFF
--- a/src/master_gateway.js
+++ b/src/master_gateway.js
@@ -336,10 +336,10 @@ var masterGateway = {
                 rejectTimeout = null;
                 if (response.promiseResult === 'resolve') {
                     logger.out('info', '[GG] Slave.' +  self.slaveId + 'Promise resolved for event ' + event);
-                    resolve(response);
+                    resolve(response.data);
                 } else {
                     logger.out('info', '[GG] Slave.' +  self.slaveId + 'Promise rejected for event ' + event);
-                    reject(response);
+                    reject(response.data);
                 }
                
             });

--- a/src/pub_sub.js
+++ b/src/pub_sub.js
@@ -31,7 +31,7 @@ var pubSub = {
         var subscription = false;
         if(typeof callback === 'function') {
             subscription = this.subscribe(action, function(response) {
-                callback(response.data);
+                callback(response);
                 subscription.remove();
             });
         }

--- a/src/slave_gateway.js
+++ b/src/slave_gateway.js
@@ -348,10 +348,10 @@ var slaveGateway = {
                 rejectTimeout = null;
                 if (response.promiseResult === 'resolve') {
                     logger.out('info', '[GG] Slave.' +  self.slaveId + 'Promise resolved for event ' + event);
-                    resolve(response);
+                    resolve(response.data);
                 } else {
                     logger.out('info', '[GG] Slave.' +  self.slaveId + 'Promise rejected for event ' + event);
-                    reject(response);
+                    reject(response.data);
                 }
             });
 

--- a/test/pub_sub.js
+++ b/test/pub_sub.js
@@ -103,7 +103,7 @@ describe('Subscribe/Unsubscribe funcionality', function() {
         var callback = sinon.spy();
         pubSub.once('Tickets.Validate', callback);
         pubSub.publish('Tickets.Validate', eventData);
-        assert.strictEqual(callback.getCall(0).calledWith(eventData.data), true);
+        assert.strictEqual(callback.getCall(0).calledWith(eventData), true);
     });
 });
 


### PR DESCRIPTION
In #11 was detected that slave/master receives more than it should.
This was right but by limiting what's returned, we introduced new internal bug in async resolve/reject logic.

We now pass all data to resolve/reject logic while resolve/reject logic will only send response/reject data to slave/master.
