### PR TITLE
Fix sending messages to wrong frame

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "webpack",
     "serve": "webpack -w",
     "test": "mocha test --recursive",
-    "test:watch": "mocha test -w --recursive",
+    "test:watch": "mocha test -w --recursive --inspect",
     "coverage": "istanbul cover _mocha test -- --recursive",
     "lint": "eslint src",
     "precommit": "npm run lint",

--- a/src/master_gateway.js
+++ b/src/master_gateway.js
@@ -14,6 +14,11 @@ function validateSlavesConfig(slaves) {
             logger.out('critical', '[GG] Master:', 'frameId property is invalid or missing for ' + slave);
             configValid = false;
         }
+
+        if (!slaves[slave].slaveId || typeof slaves[slave].slaveId !== 'string') {
+            logger.out('critical', '[GG] Master:', 'slaveId property is invalid or missing for ' + slave);
+            configValid = false;
+        }
     }
 
     return configValid;
@@ -309,6 +314,7 @@ var masterGateway = {
         }
 
         var frame = document.getElementById(slave.frameId);
+
         if (!frame) {
             logger.out('warn', '[GG] Master:', 'IFrame element under ID ' + slave.frameId + ' is non existent.');
             return false;

--- a/src/messaging/master.js
+++ b/src/messaging/master.js
@@ -1,7 +1,13 @@
 function Porthole() {}
 
 Porthole.prototype = {
-
+    /**
+     * Emit message to IFrame element or current window
+     *
+     * @param {HTMLIFrameElement} productFrame
+     * @param {Object} data
+     * @param {String} domain
+     */
     sendMessage: function(productFrame, data, domain) {
         var targetWindow = productFrame.contentWindow || window;
         var windowDomain = domain || '*';

--- a/test/master_gateway.js
+++ b/test/master_gateway.js
@@ -1,12 +1,12 @@
 var assert = require('assert'),
     sinon = require('sinon'),
     expect = require('chai').expect,
+    instance = null,
     // eslint-disable-next-line
     dom = require('jsdom-global')('<html><div id="test-frame">Hello world</div></html>');
 
 describe('Master gateway instantiation', function() {
-    var instance,
-        Gateway = require('../src/master_gateway');
+    var Gateway = require('../src/master_gateway');
 
     it('Instantiation should fail - Configuration not passed', function() {
         instance = Gateway();
@@ -33,7 +33,8 @@ describe('Master gateway instantiation', function() {
             allowedOrigins : ['http://www.nsoft.ba'],
             products : {
                 'product': {
-                    frameId: 'product'
+                    frameId: 'test-frame',
+                    slaveId: 'product'
                 }
             }
         });
@@ -59,7 +60,7 @@ describe('Master gateway instantiation', function() {
 
     it('Adding slaves on fly should pass', function() {
         instance.addSlave({
-            frameId : 'dummy',
+            frameId : 'test-frame',
             slaveId : 'dummy'
         });
 
@@ -107,7 +108,7 @@ describe('Master gateway instantiation', function() {
     it('Send msg to all slaves should pass', function() {
         var result;
         instance.addSlave({
-            frameId : 'dummy',
+            frameId : 'test-frame',
             slaveId : 'dummy'
         });
         result = instance.sendToAll('Test msg', '*');
@@ -132,30 +133,14 @@ describe('Master gateway message exchange', function() {
     });
 
     it('Should send message', function() {
-        var instance = Gateway({
-            allowedOrigins : ['http://www.nsoft.ba'],
-            products : {
-                'product': {
-                    frameId: 'product'
-                }
-            }
-        });
         var spy = sinon.spy(masterPorthole, 'sendMessage');
-        instance.sendMessage('test-frame', {}, '*');
+        instance.sendMessage('dummy', {}, '*');
         assert.equal(spy.called, true);
     });
 
     it('Should call subscribeCrossContextCallbacks', function() {
-        var instance = Gateway({
-            allowedOrigins : ['http://www.nsoft.ba'],
-            products : {
-                'product': {
-                    frameId: 'product'
-                }
-            }
-        });
         var spy = sinon.spy(instance, 'subscribeCrossContextCallbacks');
-        instance.sendMessage('test-frame', {
+        instance.sendMessage('dummy', {
             action : 'Widget.TestMsg',
             callbacks : [
                 {
@@ -170,14 +155,6 @@ describe('Master gateway message exchange', function() {
     });
 
     it('Should succesfully subscribe cross context callbacks', function() {
-        var instance = Gateway({
-            allowedOrigins : ['http://www.nsoft.ba'],
-            products : {
-                'product': {
-                    frameId: 'product'
-                }
-            }
-        });
         var msgData =  {
             action : 'Widget.TestMsg',
             callbacks : [
@@ -189,19 +166,11 @@ describe('Master gateway message exchange', function() {
                 }
             ]
         };
-        instance.sendMessage('test-frame', msgData, '*');
+        instance.sendMessage('dummy', msgData, '*');
         expect(msgData.callbacks[0].cbHash).to.be.a('string');
     });
 
     it('Should call parseCrossContextCallbacks', function() {
-        var instance = Gateway({
-            allowedOrigins : ['http://www.nsoft.ba'],
-            products : {
-                'product': {
-                    frameId: 'product'
-                }
-            }
-        });
         var spy = sinon.spy(instance, 'parseCrossContextCallbacks');
         var eventData = {
             data: {
@@ -223,14 +192,6 @@ describe('Master gateway message exchange', function() {
     });
 
     it('parseCrossContextCallbacks should attach methods', function() {
-        var instance = Gateway({
-            allowedOrigins : ['http://www.nsoft.ba'],
-            products : {
-                'dummy': {
-                    frameId: 'dummy'
-                }
-            }
-        });
         var eventData = {
             data: {
                 action: 'Widget.TestMsg',
@@ -252,7 +213,6 @@ describe('Master gateway message exchange', function() {
     });
 
     it('parseCrossContextCallbacks should call sendMessageAsync', function() {
-        var instance = Gateway();
         var spy = sinon.spy(instance, 'sendMessageAsync');
         var eventData = {
             data: {
@@ -274,14 +234,6 @@ describe('Master gateway message exchange', function() {
     });
 
     it('Should succesfully subscribe cross context callback', function() {
-        var instance = Gateway({
-            allowedOrigins : ['http://www.nsoft.ba'],
-            products : {
-                'product': {
-                    frameId: 'product'
-                }
-            }
-        });
         var msgData =  {
             action : 'Widget.TestMsg',
             callback : {
@@ -291,19 +243,11 @@ describe('Master gateway message exchange', function() {
                 }
             }
         };
-        instance.sendMessage('test-frame', msgData, '*');
+        instance.sendMessage('dummy', msgData, '*');
         expect(msgData.callback.cbHash).to.be.a('string');
     });
 
     it('Should succesfully subscribe once', function() {
-        var instance = Gateway({
-            allowedOrigins : ['http://www.nsoft.ba'],
-            products : {
-                'dummy': {
-                    frameId: 'dummy'
-                }
-            }
-        });
         var result = instance.once('betslip.toggle', function() {
             // eslint-disable-next-line
             var onceValue = true;
@@ -313,14 +257,6 @@ describe('Master gateway message exchange', function() {
     });
 
     it('Executing once subscription: Should be succesfull', function() {
-        var instance = Gateway({
-            allowedOrigins : ['http://www.nsoft.ba'],
-            products : {
-                'dummy': {
-                    frameId: 'dummy'
-                }
-            }
-        });
         var eventData = {
             data: {
                 action: 'betslip.toggle_bet',


### PR DESCRIPTION
Fix not using frameId as only way to query iframe element.
    
We have slaveId and frameId. frameId is id of a iframe element while slaveid represent instance of slave.
This way we can give different id to iframe element.

Although slaveId is required we didn't force this trough validation logic so this will be minor tag in order not to break release.