### PR TITLE
Fix scroll event data top and left properties in non-quirks mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.16.0 (2022-02-09)
+
+#### Fixed
+
+- Fix scroll event data top and left properties in non-quirks mode (#26)
+
 ## 1.15.1 (2022-01-20)
 
 #### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/seven-gravity-gateway",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nsoft/seven-gravity-gateway",
   "private": false,
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Seven Gravity Gateway",
   "homepage": "https://github.com/nsftx/seven-gravity-gateway",
   "scripts": {

--- a/src/event_dispatching/event_handler.js
+++ b/src/event_dispatching/event_handler.js
@@ -57,11 +57,14 @@ EventHandler.prototype = {
     },
 
     handleScrollEvent : function(e) {
+        var scrollTop = window.scrollY || document.documentElement.scrollTop || document.body.scrollTop;
+        var scrollLeft = window.scrollX || document.documentElement.scrollLeft || document.body.scrollLeft;
+
         var data = {
             action : this.eventName,
             event : e.type,
-            top: window.document.body.scrollTop,
-            left:  window.document.body.scrollLeft,
+            top: scrollTop,
+            left:  scrollLeft,
             totalHeight: window.innerHeight,
             totalWidth : window.innerWidth
         };


### PR DESCRIPTION
Browsers in regular non-quirks mode don't have `document.body.scrollTop` and `document.body.scrollLeft`.

For top use `window.pageY` as first and standard way of geting top scroll position, fallback to `document.documentElement.scrollTop` and finally to `document.body.scrollTop` to cover quirks mode.
For left use `window.pageX` as first and standard way of geting top scroll position, fallback to `document.documentElement.scrollLeft` and finally to `document.body.scrollLeft`

#### Phabricator task

[T122550](https://phabricator.nsoft.ba/T122550)