### PR TITLE
Update SQ action

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -8,6 +8,7 @@ jobs:
   sq_scan_job:
     runs-on: ubuntu-latest
     name: SonarQube scan
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Don't run SQ action on Dependabot PR as it doesn't make much sense to run code quality on dependency change.