### PR TITLE
Bug with before prefix

### DIFF
--- a/src/plugin/barcode-scan.js
+++ b/src/plugin/barcode-scan.js
@@ -41,6 +41,13 @@ function processKeyEvent(e) {
         return scanResult;
     }
 
+    // in case when we recive space,
+    // we want to strip any previous char,
+    // this will happen if we have scanner with hardcoded prefix (e.g. ctrl+b)
+    if (isPrefixTriggered) {
+        scanResult.code = '';
+    }
+
     // let's add previous char to list of scanned codes if time passed
     // before previous and current is below treshold
     // this will happen if scan barcode without space prefix

--- a/test/plugin-barcode-scan.js
+++ b/test/plugin-barcode-scan.js
@@ -26,33 +26,58 @@ describe('Barcode scan', function() {
         var spy = sinon.spy(slaveInstance, 'emit');
         var result = '8x2lh2g02';
         var event = new KeyboardEvent('keydown', {'code': 'space'});
+        var enterEvent = new KeyboardEvent('keydown', {'key': 'Enter', 'code': 'Enter'});
         document.dispatchEvent(event);
         result.split('').forEach(function(c) {
-            var event = new KeyboardEvent('keydown', { 'key': c });
+            var event = new KeyboardEvent('keydown', { 'key': c, 'code': `Key${c.toUpperCase()}` });
             document.dispatchEvent(event);
         });
-      
-        assert(spy.calledWith, {
+        document.dispatchEvent(enterEvent);
+        assert(spy.calledWith(sinon.match({
             action: 'Slave.ScanFinished',
-            data: {
-                code: result
-            }
-        });
+            data: { code: result }
+        })));
     });
 
     it('should emit Slave.ScanFinished when scan is finished without prefix', function() {
         var spy = sinon.spy(slaveInstance, 'emit');
         var result = '8x2lh2g02';
+        var enterEvent = new KeyboardEvent('keydown', {'key': 'Enter', 'code': 'Enter'});
         result.split('').forEach(function(c) {
-            var event = new KeyboardEvent('keydown', { 'key': c });
+            var event = new KeyboardEvent('keydown', { 'key': c, 'code': `Key${c.toUpperCase()}` });
             document.dispatchEvent(event);
         });
-      
-        assert(spy.calledWith, {
+        document.dispatchEvent(enterEvent);
+        assert(spy.calledWith(sinon.match({
+            action: 'Slave.ScanFinished',
+            data: { code: result }
+        })));
+    });
+
+    it('xxshould emit Slave.ScanFinished when scan is finished without prefix', function() {
+        var spy = sinon.spy(slaveInstance, 'emit');
+        var keys = ['Ctrl', 'b', { 'key': ' ', 'code': 'Space' }, '8', 'x', '2', 'l', 'h', '2', 'g', '0', '2'];
+        var result = '8x2lh2g02';
+        var enterEvent = new KeyboardEvent('keydown', {'key': 'Enter', 'code': 'Enter'});
+        keys.forEach(function(c) {
+            var key;
+            var code;
+            if( Object.prototype.toString.call(c) === '[object Object]' ) {
+                key = c.key;
+                code = c.code;
+            } else {
+                key = c;
+                code = `Key${c.toUpperCase()}`;
+            }
+            var event = new KeyboardEvent('keydown', { 'key': key, 'code': code });
+            document.dispatchEvent(event);
+        });
+        document.dispatchEvent(enterEvent);
+        assert(spy.calledWith(sinon.match({
             action: 'Slave.ScanFinished',
             data: {
                 code: result
             }
-        });
+        })));
     });
 });


### PR DESCRIPTION
Fix including barcode scanner prefix in final code when we have space as starting point.

We have scanner that will emit ctrl+b before it picks up values from barcode.
We must exluce them from final result. Only way to do it without re-configuratio of scanner is to remove them from final input if we have space inside barcode value.
This will not fix case when we don't have space inside barcode value.