### PR TITLE
Task/cu 2d9b27u/seven gravity gateway   rise up scan treshold if in scan mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-## 1.16.4 (2022-05-23)
+## 1.16.5 (2022-06-25)
+#### Fixed
+
+- Fixed barcode plugin not picking up codes on low end machines (#37)
+
+## 1.16.5 (2022-06-24)
 #### Added
 
 - Added logs to track diff between keydown's inside barcode plugin (#36)
-## 1.16.3 (2022-05-17)
+## 1.16.4 (2022-05-17)
 #### Added
 
 - Added logs to barcode plugin (#34)

--- a/src/plugin/barcode-scan.js
+++ b/src/plugin/barcode-scan.js
@@ -1,7 +1,7 @@
 var logger = require('../utils/utils').logger;
 
 var config = {
-    treshold: 100,
+    treshold: 50,
     prefix: 'space',
     regex: {
         pattern: /^[A-Za-z0-9.\-%]$/,

--- a/src/plugin/barcode-scan.js
+++ b/src/plugin/barcode-scan.js
@@ -19,10 +19,13 @@ var previousKey = {
 };
 var previousEventReceived = Date.now();  // time when previous event was received (time based scanning)
 var difference = 0;
+var inScanMode = false;
+var secureTimerOff = null;
 
 function processKeyEvent(e) {
     var whitelistedKeys = new RegExp(config.regex.pattern, config.regex.flags); // Array of key codes whose values wont't be concat with ticketId (enter, shift, space, arrow down)
     var isPrefixTriggered = isPrefixBased(e);
+    var treshold = config.treshold;
 
     currentTime = Date.now();
     difference = currentTime - previousEventReceived;
@@ -35,11 +38,16 @@ function processKeyEvent(e) {
         difference
     );
 
+    if (inScanMode) {
+        treshold += 100;
+        logger.out('debug', '[GGP] Plugin Barcode: Set treshold to:', treshold);
+    }
+
     // Too much difference between characters - which means that this is not scan mode.
     // First time, difference is equal to current time, so we will extract that from check.
     // We also prevent scan trigger if somone holds key (e.repeat).
     // Last flag is when space is trigered as first char, we want to enter in scan mode 
-    if ((difference > config.treshold 
+    if ((difference > treshold
         && difference !== currentTime 
         && !isPrefixTriggered)
         || e.repeat) {
@@ -50,7 +58,7 @@ function processKeyEvent(e) {
         logger.out('debug', '[GGP] Plugin Barcode: Reset.',
             difference,
             isPrefixTriggered,
-            config.treshold
+            treshold
         );
         return scanResult;
     }
@@ -61,6 +69,11 @@ function processKeyEvent(e) {
     if (isPrefixTriggered) {
         logger.out('debug', '[GGP] Plugin Barcode: Space triggered, reset final code.');
         scanResult.code = '';
+        inScanMode = true;
+        secureTimerOff = setTimeout(function(){
+            inScanMode = false;
+            logger.out('debug', '[GGP] Plugin Barcode: Secure timer off triggered.');
+        }, 2000);
     }
 
     // let's add previous char to list of scanned codes if time passed
@@ -68,7 +81,7 @@ function processKeyEvent(e) {
     // this will happen if scan barcode without space prefix
     if (scanResult.code.length === 0
         && !isPrefixTriggered
-        && (previousKey.event && (currentTime - previousKey.receivedAt) < (config.treshold * 2))
+        && (previousKey.event && (currentTime - previousKey.receivedAt) < (treshold * 2))
         && whitelistedKeys.test(previousKey.event.key)
     ) {
         logger.out('debug', '[GGP] Plugin Barcode: Adding previous key.', e.code, e.key);
@@ -99,6 +112,8 @@ function processKeyEvent(e) {
 
         if (scanResult.code.length) {
             scanResult.finished = true;
+            inScanMode = false;
+            clearTimeout(secureTimerOff);
         }
     }
     return scanResult;

--- a/test/plugin-barcode-scan.js
+++ b/test/plugin-barcode-scan.js
@@ -86,8 +86,6 @@ describe('Barcode scan', function() {
         var keys = ['Ctrl', 'b', { 'key': ' ', 'code': 'Space' }, '8', 'x', '2', 'l', 'h', '2', 'g', '0', '2'];
         var result = '8x2lh2g02';
         var enterEvent = new KeyboardEvent('keydown', {'key': 'Enter', 'code': 'Enter'});
-        var event = new KeyboardEvent('keydown', {'code': 'space'});
-        // document.dispatchEvent(event);
         keys.forEach(function(c) {
             var key;
             var code;

--- a/test/plugin-barcode-scan.js
+++ b/test/plugin-barcode-scan.js
@@ -54,10 +54,10 @@ describe('Barcode scan', function() {
         })));
     });
 
-    it('xxshould emit Slave.ScanFinished when scan is finished without prefix', function() {
+    it('should emit Slave.ScanFinished when scan is finished without prefix', function() {
         var spy = sinon.spy(slaveInstance, 'emit');
-        var keys = ['Ctrl', 'b', { 'key': ' ', 'code': 'Space' }, '8', 'x', '2', 'l', 'h', '2', 'g', '0', '2'];
-        var result = '8x2lh2g02';
+        var keys = ['Ctrl', 'b', '8', 'x', '2', 'l', 'h', '2', 'g', '0', '2'];
+        var result = 'b8x2lh2g02';
         var enterEvent = new KeyboardEvent('keydown', {'key': 'Enter', 'code': 'Enter'});
         keys.forEach(function(c) {
             var key;
@@ -79,5 +79,38 @@ describe('Barcode scan', function() {
                 code: result
             }
         })));
+    });
+
+    it('should emit Slave.ScanFinished when diff between keys is higher than default value', function(done) {
+        var spy = sinon.spy(slaveInstance, 'emit');
+        var keys = ['Ctrl', 'b', { 'key': ' ', 'code': 'Space' }, '8', 'x', '2', 'l', 'h', '2', 'g', '0', '2'];
+        var result = '8x2lh2g02';
+        var enterEvent = new KeyboardEvent('keydown', {'key': 'Enter', 'code': 'Enter'});
+        var event = new KeyboardEvent('keydown', {'code': 'space'});
+        // document.dispatchEvent(event);
+        keys.forEach(function(c) {
+            var key;
+            var code;
+            if( Object.prototype.toString.call(c) === '[object Object]' ) {
+                key = c.key;
+                code = c.code;
+            } else {
+                key = c;
+                code = `Key${c.toUpperCase()}`;
+            }
+            var event = new KeyboardEvent('keydown', { 'key': key, 'code': code });
+            document.dispatchEvent(event);
+        });
+
+        setTimeout(function() {
+            document.dispatchEvent(enterEvent);
+            assert(spy.calledWith(sinon.match({
+                action: 'Slave.ScanFinished',
+                data: {
+                    code: result
+                }
+            })));
+            done();
+        }, 100);
     });
 });


### PR DESCRIPTION
Problem
Time based scan mode on older machines can result in many incorrect results. We assume that it will take 40 ms between key strokes but this is not true. It can last much longer.

Solution
If we are in scan mode rise up treshold and after scan mode is over bring it down to standard value. This way we give more time between key strokes.

This will not work, for now, if we don't have space as prefix. This implementation is only for Seven based tickets.