### PR TITLE
Task/cu 2dezrtn/seven gravity gateway   fix prevening keydowns after scan is finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.16.5 (2022-06-25)
+## 1.16.7 (2022-06-25)
+#### Fixed
+
+- Fixed barcode plugin stoping propagation of keydown after scan is finished (#38)
+
+## 1.16.6 (2022-06-25)
 #### Fixed
 
 - Fixed barcode plugin not picking up codes on low end machines (#37)

--- a/src/plugin/barcode-scan.js
+++ b/src/plugin/barcode-scan.js
@@ -35,7 +35,9 @@ function processKeyEvent(e) {
         e.code,
         e.key,
         e.repeat,
-        difference
+        difference,
+        currentTime,
+        previousEventReceived
     );
 
     if (inScanMode) {
@@ -108,8 +110,6 @@ function processKeyEvent(e) {
     }
 
     if (e.key.toLowerCase() === 'enter') {
-        previousEventReceived = 0;
-
         if (scanResult.code.length) {
             scanResult.finished = true;
             inScanMode = false;

--- a/test/plugin-barcode-scan.js
+++ b/test/plugin-barcode-scan.js
@@ -111,4 +111,39 @@ describe('Barcode scan', function() {
             done();
         }, 100);
     });
+
+    it('should not stop propagatin after scan is finished', function(done) {
+        var spy = sinon.spy(slaveInstance, 'emit');
+        var keys = ['Ctrl', 'b', { 'key': ' ', 'code': 'Space' }, '8', 'x', '2', 'l', 'h', '2', 'g', '0', '2'];
+        var result = '8x2lh2g02';
+        var enterEvent = new KeyboardEvent('keydown', {'key': 'Enter', 'code': 'Enter'});
+        var onKeyDownCallback = sinon.spy();
+        window.document.addEventListener('keydown', onKeyDownCallback);
+        keys.forEach(function(c) {
+            var key;
+            var code;
+            if( Object.prototype.toString.call(c) === '[object Object]' ) {
+                key = c.key;
+                code = c.code;
+            } else {
+                key = c;
+                code = `Key${c.toUpperCase()}`;
+            }
+            var event = new KeyboardEvent('keydown', { 'key': key, 'code': code });
+            document.dispatchEvent(event);
+        });
+
+        document.dispatchEvent(enterEvent);
+        assert(spy.calledWith(sinon.match({
+            action: 'Slave.ScanFinished',
+            data: {
+                code: result
+            }
+        })));
+        setTimeout(function() {
+            document.dispatchEvent(new KeyboardEvent('keydown', {'key': 'Enter', 'code': 'Enter'}));
+            assert(onKeyDownCallback.called);
+            done();
+        }, 51);
+    });
 });


### PR DESCRIPTION
This can happen if the end user press Enter or any other char after previus scan is over.
previousEventReceived would be set to 0 resulting in difference === currentTime so it would go over that part of code and execute stop propagation