### PR TITLE
Add back ignored src

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 .idea/*
 .vscode/*
 node_modules/*
-src
 test
 npm-debug.log
 sonar-project.properties


### PR DESCRIPTION
Files in root that are exposed use src.
Bringing this back to prevent breaking other projects, this may be reworked in future