### PR TITLE
2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nsftx/seven-gravity-gateway",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nsftx/seven-gravity-gateway",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "chai": "~4.3.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nsftx/seven-gravity-gateway",
   "private": false,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Seven Gravity Gateway",
   "homepage": "https://github.com/nsftx/seven-gravity-gateway",
   "scripts": {


### PR DESCRIPTION
## What's Changed
* Bump tough-cookie from 4.0.0 to 4.1.3 by @dependabot in https://github.com/nsftx/seven-gravity-gateway/pull/61
* Bump word-wrap from 1.2.3 to 1.2.4 by @dependabot in https://github.com/nsftx/seven-gravity-gateway/pull/62
* Bump @babel/traverse from 7.16.5 to 7.23.2 by @dependabot in https://github.com/nsftx/seven-gravity-gateway/pull/63
* Bump browserify-sign from 4.0.4 to 4.2.2 by @dependabot in https://github.com/nsftx/seven-gravity-gateway/pull/64
* Task/cu 86942hp4v/7 shop   create retail plugin for gg by @thedev966 in https://github.com/nsftx/seven-gravity-gateway/pull/69
* Task/cu 86942v80e/7 shop   bundle up retail plugins in gg by @thedev966 in https://github.com/nsftx/seven-gravity-gateway/pull/70


**Full Changelog**: https://github.com/nsftx/seven-gravity-gateway/compare/v2.3.0...v2.4.0